### PR TITLE
Stages/2025 patches for CLM3.5

### DIFF
--- a/bld/Makefile.in
+++ b/bld/Makefile.in
@@ -378,7 +378,15 @@ ifeq ($(FC),lf95)
 
 endif
 
+MPI_FC := FALSE
 ifeq ($(findstring mpif90,$(FC)),mpif90)
+  MPI_FC := TRUE
+endif
+ifeq ($(findstring mpifort,$(FC)),mpifort)
+  MPI_FC := TRUE
+endif
+
+ifeq ($(MPI_FC),TRUE)
   ifeq ($(findstring ifort,$(shell $(FC) --version)),ifort)
     #ifort
     FFLAGS      := $(cpp_path) $(mod_path) $(PSMILE_INCDIR) $(CPPDEF1) $(CPPDEF) -132 -ftz -g

--- a/bld/Makefile.in
+++ b/bld/Makefile.in
@@ -403,7 +403,7 @@ ifeq ($(findstring mpif90,$(FC)),mpif90)
   else
     #gfortran
     FFLAGS      := $(cpp_path) $(mod_path) $(PSMILE_INCDIR) $(CPPDEF1) $(CPPDEF)
-    FFLAGS      += -fno-range-check
+    FFLAGS      += -fno-range-check -fallow-argument-mismatch -fallow-invalid-boz
     FREEFLAGS   := -ffree-form
     FIXEDFLAGS  :=
     LDFLAGS     := $(LIBNETCDF_FLAG) $(LIBOASIS) $(LIBPSMILE)

--- a/src/csm_share/shr/shr_sys_mod.F90
+++ b/src/csm_share/shr/shr_sys_mod.F90
@@ -42,7 +42,7 @@ SUBROUTINE shr_sys_system(str,rcode)
 #if (defined CRAY) || (defined UNICOSMP)
    integer(SHR_KIND_IN),external    :: ishell ! function to envoke shell command
 #endif
-#if (defined OSF1 || defined SUNOS || (defined LINUX && !defined G95) || (defined LINUX && !defined CATAMOUNT))
+#if (!defined __GFORTRAN__) && (defined OSF1 || defined SUNOS || (defined LINUX && !defined G95) || (defined LINUX && !defined CATAMOUNT))
    integer(SHR_KIND_IN),external    :: system ! function to envoke shell command
 #endif
 
@@ -135,7 +135,7 @@ SUBROUTINE shr_sys_chdir(path, rcode)
 
    !----- local -----
    integer(SHR_KIND_IN)             :: lenpath ! length of path
-#if (defined AIX || defined OSF1 || defined SUNOS || (defined LINUX && !defined G95) || defined NEC_SX)
+#if (!defined __GFORTRAN__) && (defined AIX || defined OSF1 || defined SUNOS || (defined LINUX && !defined G95) || defined NEC_SX)
    integer(SHR_KIND_IN),external    :: chdir   ! AIX system call
 #endif
 

--- a/src/utils/mct/mpeu/m_FileResolv.F90
+++ b/src/utils/mct/mpeu/m_FileResolv.F90
@@ -97,7 +97,7 @@ CONTAINS
 
 #if SYSUNICOS || CPRCRAY
    integer, external  :: ishell
-#else
+#elif (!defined __GFORTRAN__)
    integer, external  :: system
 #endif
    character(len=255) :: path, host, dirn, basen, head, tail, cmd, filen


### PR DESCRIPTION
- Introduce Fortran flags `-fallow-argument-mismatch -fallow-invalid-boz`
- Used `system()` and `chdir()` intrinsics when compiling in gfortran
- Acknowledge both mpif90 and mpifort as valid MPI Fortran compilers

Related to https://github.com/HPSCTerrSys/TSMP2/pull/61